### PR TITLE
Remove GCImporter15 reference

### DIFF
--- a/stringer.go
+++ b/stringer.go
@@ -72,8 +72,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	_ "golang.org/x/tools/go/gcimporter15"
 )
 
 // Generator holds the state of the analysis. Primarily used to buffer


### PR DESCRIPTION
I do not believe this reference is needed anymore, and it breaks the package since the tool is no longer available.



